### PR TITLE
Reroute HTTP generation through our requests wrapper.

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/requests.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/requests.jinja2
@@ -17,7 +17,7 @@ def {{ operation_id }}({{ params }} api_config_override : Optional[APIConfig] = 
 
     query_params = {key:value for (key,value) in query_params.items() if value is not None}
 
-    response = requests.request(
+    response = request(
         '{{ method }}',
         f'{base_path}{path}',
         headers=headers,

--- a/src/openapi_python_generator/language_converters/python/templates/service.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/service.jinja2
@@ -1,11 +1,11 @@
 from typing import *
-import {{ library_import }}
 import json
 {% if use_orjson %}
 import orjson
 {% endif %}
 
 from ..models import *
+from ..requests import request
 from ..api_config import APIConfig, HTTPException
 
 {{ content | safe}}


### PR DESCRIPTION
 - Disable switching between HTTP implementations.
 - Add relative import to local requests wrapper.